### PR TITLE
feat: include Telegram reply context in brain messages

### DIFF
--- a/channels/telegram/bot.py
+++ b/channels/telegram/bot.py
@@ -255,7 +255,9 @@ class TelegramBot:
         )
 
         # Build a context message for the brain
+        reply_ctx = self._build_reply_context(update)
         user_message = (
+            f"{reply_ctx}"
             f"[System: the user sent a file named '{filename}' "
             f"which has been saved to {save_path}]\n"
             f"{caption if caption else 'Please help me set up or use this file.'}"
@@ -338,12 +340,14 @@ class TelegramBot:
         except Exception as e:
             logger.error(f"Transcription failed for {filename}: {e}")
 
+        reply_ctx = self._build_reply_context(update)
         if transcript:
-            user_message = transcript
+            user_message = f"{reply_ctx}{transcript}"
             if caption:
-                user_message = f"{transcript}\n\n[User note: {caption}]"
+                user_message = f"{reply_ctx}{transcript}\n\n[User note: {caption}]"
         else:
             user_message = (
+                f"{reply_ctx}"
                 f"[System: the user sent a voice/audio message saved to {save_path}. "
                 "Transcription is unavailable — nemo_toolkit may not be installed.]\n"
                 f"{caption or 'The user sent an audio message.'}"
@@ -393,8 +397,11 @@ class TelegramBot:
 
         image_data = base64.b64encode(image_bytes).decode()
 
-        # Build multimodal content: optional text caption + image block
+        # Build multimodal content: optional reply context + text caption + image block
         content: list = []
+        reply_ctx = self._build_reply_context(update)
+        if reply_ctx:
+            content.append({"type": "text", "text": reply_ctx.rstrip()})
         if caption:
             content.append({"type": "text", "text": caption})
         content.append(
@@ -416,13 +423,55 @@ class TelegramBot:
             logger.exception("Error processing photo")
             await update.message.reply_text(f"⚠️ Something went wrong: {e}")
 
+    @staticmethod
+    def _build_reply_context(update: Update) -> str:
+        """
+        If the incoming message is a reply to another message, return a string
+        describing the original message so the brain has context.
+
+        Returns an empty string when the message is not a reply.
+        """
+        replied = update.message.reply_to_message
+        if not replied:
+            return ""
+
+        # Prefer plain text, then caption (media messages), then media type label
+        if replied.text:
+            quoted = replied.text
+        elif replied.caption:
+            quoted = replied.caption
+        elif replied.photo:
+            quoted = "[photo]"
+        elif replied.document:
+            name = getattr(replied.document, "file_name", None) or "file"
+            quoted = f"[document: {name}]"
+        elif replied.voice or replied.audio:
+            quoted = "[voice/audio message]"
+        elif replied.sticker:
+            quoted = f"[sticker: {replied.sticker.emoji or ''}]"
+        else:
+            quoted = "[message]"
+
+        # Truncate very long quoted messages to keep the prompt readable
+        if len(quoted) > 300:
+            quoted = quoted[:297] + "…"
+
+        sender = ""
+        if replied.from_user:
+            sender = replied.from_user.first_name or replied.from_user.username or ""
+
+        if sender:
+            return f'[Replying to {sender}: "{quoted}"]\n'
+        return f'[Replying to: "{quoted}"]\n'
+
     async def _handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         user = update.effective_user
         if not self._is_allowed(user.id):
             await update.message.reply_text("⛔ Unauthorized.")
             return
 
-        user_text = update.message.text
+        reply_ctx = self._build_reply_context(update)
+        user_text = (reply_ctx + update.message.text) if reply_ctx else update.message.text
         user_id = str(user.id)
 
         logger.info(f"Message from {user.username or user.id}: {user_text[:100]}")

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -251,3 +251,121 @@ async def test_web_push_message_logs(tmp_memory, empty_skills, caplog):
         await bot.push_message("Proactive!", [])
 
     assert any("push" in r.message.lower() for r in caplog.records)
+
+
+# ── Telegram reply context ──────────────────────────────────────────────────────
+
+
+def _make_telegram_bot(brain):
+    """Create a TelegramBot with a fake token (no real connection)."""
+    with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "fake-token-for-tests"}):
+        with patch("channels.telegram.bot.Application"):
+            from channels.telegram.bot import TelegramBot
+
+            bot = TelegramBot(brain=brain)
+    return bot
+
+
+def _make_update(replied_text=None, replied_caption=None, replied_media=None, sender_name=None):
+    """Build a minimal mock Update with an optional reply_to_message."""
+    from unittest.mock import MagicMock
+
+    update = MagicMock()
+
+    if replied_text is None and replied_caption is None and replied_media is None:
+        update.message.reply_to_message = None
+        return update
+
+    replied = MagicMock()
+    replied.text = replied_text
+    replied.caption = replied_caption
+
+    # Set all media attributes to None by default
+    replied.photo = None
+    replied.document = None
+    replied.voice = None
+    replied.audio = None
+    replied.sticker = None
+
+    if replied_media == "photo":
+        replied.photo = MagicMock()
+    elif replied_media == "document":
+        doc = MagicMock()
+        doc.file_name = "report.pdf"
+        replied.document = doc
+    elif replied_media == "voice":
+        replied.voice = MagicMock()
+
+    if sender_name:
+        replied.from_user = MagicMock()
+        replied.from_user.first_name = sender_name
+        replied.from_user.username = sender_name
+    else:
+        replied.from_user = None
+
+    update.message.reply_to_message = replied
+    return update
+
+
+def test_telegram_build_reply_context_no_reply(tmp_memory, empty_skills):
+    """Returns empty string when the message is not a reply."""
+    brain, _ = make_brain([], tmp_memory, empty_skills)
+    bot = _make_telegram_bot(brain)
+
+    update = _make_update()
+    assert bot._build_reply_context(update) == ""
+
+
+def test_telegram_build_reply_context_text_reply(tmp_memory, empty_skills):
+    """Quoted text appears in the context string."""
+    brain, _ = make_brain([], tmp_memory, empty_skills)
+    bot = _make_telegram_bot(brain)
+
+    update = _make_update(replied_text="What's the weather today?", sender_name="Alice")
+    ctx = bot._build_reply_context(update)
+    assert "Alice" in ctx
+    assert "What's the weather today?" in ctx
+
+
+def test_telegram_build_reply_context_no_sender(tmp_memory, empty_skills):
+    """Works correctly when the sender name is unavailable."""
+    brain, _ = make_brain([], tmp_memory, empty_skills)
+    bot = _make_telegram_bot(brain)
+
+    update = _make_update(replied_text="Hello world")
+    ctx = bot._build_reply_context(update)
+    assert "Hello world" in ctx
+    assert ctx.startswith("[Replying to:")
+
+
+def test_telegram_build_reply_context_photo_reply(tmp_memory, empty_skills):
+    """Returns [photo] label when replying to a photo with no caption."""
+    brain, _ = make_brain([], tmp_memory, empty_skills)
+    bot = _make_telegram_bot(brain)
+
+    update = _make_update(replied_media="photo")
+    ctx = bot._build_reply_context(update)
+    assert "[photo]" in ctx
+
+
+def test_telegram_build_reply_context_document_reply(tmp_memory, empty_skills):
+    """Returns file name label when replying to a document."""
+    brain, _ = make_brain([], tmp_memory, empty_skills)
+    bot = _make_telegram_bot(brain)
+
+    update = _make_update(replied_media="document")
+    ctx = bot._build_reply_context(update)
+    assert "report.pdf" in ctx
+
+
+def test_telegram_build_reply_context_truncates_long_text(tmp_memory, empty_skills):
+    """Very long quoted messages are truncated at 300 characters."""
+    brain, _ = make_brain([], tmp_memory, empty_skills)
+    bot = _make_telegram_bot(brain)
+
+    long_text = "a" * 500
+    update = _make_update(replied_text=long_text)
+    ctx = bot._build_reply_context(update)
+    # The context string itself will be longer than 300 due to prefix, but quoted portion ≤ 300
+    assert "…" in ctx
+    assert long_text[:50] in ctx


### PR DESCRIPTION
Fixes #3

When a user replies to a message in Telegram, the assistant now receives the original message content as a `[Replying to: "..."]` prefix so it can understand the full conversational context.

Handles text, caption, photo, document, voice/audio, and sticker replies across all four message handlers.

Generated with [Claude Code](https://claude.ai/code)