### PR TITLE
fix: replace asyncio subprocess with subprocess.run in executor for code_runner and shell_exec

### DIFF
--- a/skills/code_runner/tool.py
+++ b/skills/code_runner/tool.py
@@ -6,6 +6,7 @@ stdout + stderr are captured and returned as a string.
 """
 
 import asyncio
+import subprocess
 import sys
 
 PARAMETERS = {
@@ -42,27 +43,29 @@ async def run(code: str, timeout: int = 15, **kwargs) -> str:
     timeout = min(int(timeout), MAX_TIMEOUT)
 
     try:
-        proc = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-c",
-            code,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            stdin=asyncio.subprocess.DEVNULL,  # No interactive prompts
-        )
+        def _run_sync():
+            try:
+                result = subprocess.run(
+                    [sys.executable, "-c", code],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    timeout=timeout,
+                )
+                return result.stdout, result.returncode, False
+            except subprocess.TimeoutExpired as exc:
+                return (exc.output or b""), None, True
 
-        try:
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.communicate()
+        raw_stdout, returncode, timed_out = await asyncio.to_thread(_run_sync)
+
+        if timed_out:
             return f"Error: code timed out after {timeout}s"
 
-        output = stdout.decode(errors="replace").rstrip()
+        output = raw_stdout.decode(errors="replace").rstrip()
 
         if not output:
-            output = f"(no output, exit code {proc.returncode})"
-        elif proc.returncode != 0:
+            output = f"(no output, exit code {returncode})"
+        elif returncode != 0:
             # Errors are useful — don't suppress them
             pass  # Output already contains the traceback from stderr
 

--- a/skills/shell_exec/tool.py
+++ b/skills/shell_exec/tool.py
@@ -1,12 +1,13 @@
 """
 skills/shell_exec/tool.py
 
-Run shell commands asynchronously with a timeout.
+Run shell commands with a timeout.
 Output (stdout + stderr combined) is returned as a string.
 """
 
 import asyncio
 import os
+import subprocess
 from pathlib import Path
 
 PARAMETERS = {
@@ -52,27 +53,32 @@ async def run(command: str, timeout: int = 30, working_dir: str = "", **kwargs) 
         return f"Error: working directory does not exist: {cwd}"
 
     try:
-        proc = await asyncio.create_subprocess_shell(
-            command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,  # Merge stderr into stdout
-            cwd=cwd,
-            env={**os.environ},
-        )
+        def _run_sync():
+            try:
+                result = subprocess.run(
+                    command,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    cwd=cwd,
+                    env={**os.environ},
+                    timeout=timeout,
+                )
+                return result.stdout, result.returncode, False
+            except subprocess.TimeoutExpired as exc:
+                return (exc.output or b""), None, True
 
-        try:
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.communicate()
+        raw_stdout, returncode, timed_out = await asyncio.to_thread(_run_sync)
+
+        if timed_out:
             return f"Error: command timed out after {timeout}s\n$ {command}"
 
-        output = stdout.decode(errors="replace").rstrip()
+        output = raw_stdout.decode(errors="replace").rstrip()
 
         if not output:
-            output = f"(command exited with code {proc.returncode}, no output)"
-        elif proc.returncode != 0:
-            output = f"[exit code {proc.returncode}]\n{output}"
+            output = f"(command exited with code {returncode}, no output)"
+        elif returncode != 0:
+            output = f"[exit code {returncode}]\n{output}"
 
         if len(output) > MAX_OUTPUT_CHARS:
             half = MAX_OUTPUT_CHARS // 2


### PR DESCRIPTION
Fixes #8

Both skills used asyncio.create_subprocess_* which competes with the shared event loop when called via _run_skill_sync's new_event_loop(). Replaced with subprocess.run() dispatched via asyncio.to_thread() so the process runs in a thread pool, completely decoupled from any event loop.

Generated with [Claude Code](https://claude.ai/code)