### PR TITLE
feat: self-update from GitHub with periodic check and user confirmation

### DIFF
--- a/brain/engine.py
+++ b/brain/engine.py
@@ -48,6 +48,7 @@ from brain.tools import (  # noqa: F401 — re-exported for tests
     _make_reload,
     _make_manage_skills,
     _make_run_claude,
+    _make_update_self,
 )
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,7 @@ class Brain:
             _make_reflect(),
             _make_reload(state),
             _make_manage_skills(self.skills),
+            _make_update_self(self),
         ]
         if os.getenv("CLAUDE_CODE_AVAILABLE", "").lower() == "true":
             tools.append(_make_run_claude())

--- a/brain/tools.py
+++ b/brain/tools.py
@@ -352,6 +352,94 @@ def _make_run_claude() -> BrainTool:
     return _tool(run_claude)
 
 
+def _make_update_self(brain_ref) -> BrainTool:
+    async def update_self() -> str:
+        """Update Atlas to the latest version from GitHub: pulls new code, reinstalls dependencies, and restarts the service. Ask the user for confirmation before calling this."""
+        import os as _os
+        import signal as _signal
+        import subprocess as _subprocess
+
+        root = Path(__file__).parent.parent.resolve()
+
+        # Check whether an update is actually available
+        if brain_ref.heartbeat:
+            try:
+                update_available, check_msg = await brain_ref.heartbeat.check_for_update()
+                if not update_available:
+                    return f"No update available — {check_msg}"
+            except Exception as e:
+                logger.warning(f"Pre-update check failed: {e}")
+
+        # ── Step 1: git pull ────────────────────────────────────────────────────
+        try:
+            result = _subprocess.run(
+                ["git", "pull"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                cwd=root,
+            )
+            pull_out = (result.stdout + result.stderr).strip()
+            if result.returncode != 0:
+                return f"❌ git pull failed:\n{pull_out}"
+        except Exception as e:
+            return f"❌ git pull failed: {e}"
+
+        # ── Step 2: uv sync (install new / updated dependencies) ───────────────
+        try:
+            result = _subprocess.run(
+                ["uv", "sync"],
+                capture_output=True,
+                text=True,
+                timeout=180,
+                cwd=root,
+            )
+            sync_out = (result.stdout + result.stderr).strip()
+            if result.returncode != 0:
+                return f"❌ uv sync failed:\n{sync_out}\n\ngit pull output:\n{pull_out}"
+        except FileNotFoundError:
+            sync_out = "uv not found — skipping dependency sync"
+            logger.warning(sync_out)
+        except Exception as e:
+            return f"❌ uv sync failed: {e}\n\ngit pull output:\n{pull_out}"
+
+        logger.info(f"Update applied — git pull: {pull_out[:80]}")
+
+        # ── Step 3: restart ─────────────────────────────────────────────────────
+        # Try systemd first (the normal production deployment path).
+        try:
+            result = _subprocess.run(
+                ["systemctl", "--user", "restart", "atlas"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return (
+                    f"✅ Atlas updated and restarted via systemd.\n\n"
+                    f"git pull: {pull_out}"
+                )
+        except Exception:
+            pass  # systemd not available — fall back to in-process restart
+
+        # Fall back: signal the main loop to restart (works in --watch / CLI mode)
+        logger.info("Systemd restart unavailable — requesting in-process restart")
+        _os.environ["_ATLAS_RESTART"] = "1"
+        _os.kill(_os.getpid(), _signal.SIGTERM)
+        return f"✅ Atlas updated — restarting now.\n\ngit pull: {pull_out}"
+
+    return BrainTool(
+        name="update_self",
+        description=(
+            "Update Atlas to the latest version from GitHub. "
+            "Pulls new code, reinstalls dependencies, and restarts the service. "
+            "Always confirm with the user before calling this tool."
+        ),
+        parameters={"type": "object", "properties": {}},
+        func=update_self,
+    )
+
+
 def _make_manage_skills(skills: SkillRegistry) -> BrainTool:
     def manage_skills(
         action: str, name: str = "", skill_md: str = "", tool_py: str = ""

--- a/heartbeat/__init__.py
+++ b/heartbeat/__init__.py
@@ -23,6 +23,7 @@ from apscheduler.triggers.cron import CronTrigger
 from heartbeat.scheduler import Scheduler
 from heartbeat.awareness import Awareness
 from heartbeat.maintenance import run_maintenance
+from heartbeat.updater import Updater
 
 logger = logging.getLogger(__name__)
 
@@ -54,11 +55,13 @@ class Heartbeat:
         self._notify_callback = notify_callback
         self._scheduler = Scheduler(brain=brain, notify_callback=notify_callback)
         self._awareness = Awareness(brain=brain, notify_callback=notify_callback)
+        self._updater = Updater(notify_callback=notify_callback)
         self._maintenance_scheduler = AsyncIOScheduler()
 
     async def start(self) -> None:
         await self._scheduler.start()
         await self._awareness.start()
+        await self._updater.start()
         self._maintenance_scheduler.add_job(
             self._run_maintenance,
             trigger=CronTrigger(hour=MAINTENANCE_HOUR, minute=0),
@@ -71,9 +74,10 @@ class Heartbeat:
     async def stop(self) -> None:
         await self._scheduler.stop()
         await self._awareness.stop()
+        await self._updater.stop()
         if self._maintenance_scheduler.running:
             self._maintenance_scheduler.shutdown(wait=False)
-        logger.info("Heartbeat stopped (scheduler + awareness + maintenance)")
+        logger.info("Heartbeat stopped (scheduler + awareness + updater + maintenance)")
 
     def reload_jobs(self) -> None:
         """Reload cron jobs after a brain scheduling tool call."""
@@ -82,6 +86,10 @@ class Heartbeat:
     async def run_maintenance_now(self) -> str:
         """Run maintenance immediately (e.g. from a brain tool or test)."""
         return await self._run_maintenance()
+
+    async def check_for_update(self) -> tuple[bool, str]:
+        """Check for a GitHub update immediately and return (available, message)."""
+        return await self._updater.check_now()
 
     async def _run_maintenance(self) -> str:
         """Internal: execute daily maintenance tasks."""

--- a/heartbeat/updater.py
+++ b/heartbeat/updater.py
@@ -1,0 +1,173 @@
+"""
+heartbeat/updater.py
+
+Periodic GitHub update checker for Atlas.
+
+How it works:
+    1. Every UPDATE_CHECK_INTERVAL_HOURS hours, run `git fetch` and compare
+       the local HEAD with the remote tracking branch HEAD.
+    2. If new commits are available, notify the user via notify_callback
+       asking whether they'd like to update.
+    3. Once an update notification has been sent, it won't repeat until
+       even newer commits are detected on the remote.
+
+Usage:
+    updater = Updater(notify_callback=my_async_fn)
+    await updater.start()
+    ...
+    await updater.stop()
+"""
+
+import asyncio
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+logger = logging.getLogger(__name__)
+
+# How often to poll for updates (hours). Override with UPDATE_CHECK_INTERVAL_HOURS env var.
+UPDATE_CHECK_INTERVAL_HOURS = int(os.getenv("UPDATE_CHECK_INTERVAL_HOURS", "1"))
+
+# Project root — the git repository
+_ROOT = Path(__file__).parent.parent.resolve()
+
+
+def _run_git(*args: str, timeout: int = 15) -> tuple[int, str]:
+    """Run a git command synchronously and return (returncode, combined output)."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=_ROOT,
+        )
+        return result.returncode, (result.stdout + result.stderr).strip()
+    except subprocess.TimeoutExpired:
+        return -1, f"git {' '.join(args)} timed out after {timeout}s"
+    except FileNotFoundError:
+        return -1, "git not found on PATH"
+    except Exception as e:
+        return -1, str(e)
+
+
+def check_for_update() -> tuple[bool, str]:
+    """
+    Fetch from the remote and compare local HEAD with the upstream tracking branch.
+
+    Returns:
+        (update_available, message) — message describes what's new or why skipped.
+    """
+    # Fetch silently (do not merge)
+    code, out = _run_git("fetch", "--quiet")
+    if code != 0:
+        return False, f"git fetch failed: {out}"
+
+    # Local HEAD
+    code, local_head = _run_git("rev-parse", "HEAD")
+    if code != 0:
+        return False, f"Could not read local HEAD: {local_head}"
+
+    # Remote tracking branch HEAD (@{u} = upstream)
+    code, remote_head = _run_git("rev-parse", "@{u}")
+    if code != 0:
+        return False, "No upstream branch configured — skipping update check"
+
+    local_head = local_head.strip()
+    remote_head = remote_head.strip()
+
+    if local_head == remote_head:
+        return False, "Already up to date"
+
+    # Count commits ahead on the remote
+    code, log_out = _run_git("log", "HEAD..@{u}", "--oneline", "--no-decorate")
+    commit_lines = [ln for ln in log_out.splitlines() if ln.strip()]
+    n = len(commit_lines)
+
+    summary = f"{n} new commit(s)" if n else "new commits"
+    if commit_lines:
+        recent = commit_lines[:3]
+        subjects = "\n".join(f"  • {c}" for c in recent)
+        if n > 3:
+            subjects += f"\n  … and {n - 3} more"
+        summary = f"{n} new commit(s):\n{subjects}"
+
+    return True, summary
+
+
+class Updater:
+    """
+    Periodic update checker — fetches from GitHub and notifies the user when
+    a new version is available.
+    """
+
+    def __init__(self, notify_callback=None):
+        """
+        Args:
+            notify_callback:  async def notify(text: str, files: list) -> None
+        """
+        self.notify_callback = notify_callback
+        self._scheduler = AsyncIOScheduler()
+        self._last_reported_remote: str | None = None
+
+    async def start(self) -> None:
+        self._scheduler.add_job(
+            self._check,
+            trigger=IntervalTrigger(hours=UPDATE_CHECK_INTERVAL_HOURS),
+            id="update_check",
+            replace_existing=True,
+        )
+        self._scheduler.start()
+        logger.info(
+            f"Update checker started — polling every {UPDATE_CHECK_INTERVAL_HOURS}h"
+        )
+
+    async def stop(self) -> None:
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+        logger.info("Update checker stopped")
+
+    async def check_now(self) -> tuple[bool, str]:
+        """Run an update check immediately (off-thread so it won't block the event loop)."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, check_for_update)
+
+    async def _check(self) -> None:
+        """One scheduled update-check tick."""
+        logger.debug("Update check tick")
+
+        loop = asyncio.get_event_loop()
+        update_available, message = await loop.run_in_executor(None, check_for_update)
+
+        if not update_available:
+            logger.debug(f"Update check: {message}")
+            return
+
+        # Read the remote HEAD to avoid duplicate notifications
+        code, remote_head = await loop.run_in_executor(
+            None, lambda: _run_git("rev-parse", "@{u}")
+        )
+        remote_head = remote_head.strip()
+
+        if remote_head == self._last_reported_remote:
+            logger.debug("Update already reported for this remote HEAD — skipping")
+            return
+
+        self._last_reported_remote = remote_head
+        logger.info(f"Update available — notifying user: {message[:80]}")
+
+        notification = (
+            f"🆕 Atlas update available!\n\n{message}\n\n"
+            "Say 'update' or ask me to run `update_self` to apply it."
+        )
+        if self.notify_callback:
+            try:
+                await self.notify_callback(notification, [])
+            except Exception as e:
+                logger.exception(f"Update notify failed: {e}")
+        else:
+            logger.info(f"Update available (no notify_callback): {message}")

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -350,7 +350,7 @@ async def test_awareness_failure_doesnt_crash(tmp_memory, empty_skills, tmp_path
 async def test_heartbeat_wrapper_starts_both_components(
     tmp_memory, empty_skills, tmp_path
 ):
-    """Heartbeat facade starts both Scheduler and Awareness."""
+    """Heartbeat facade starts Scheduler, Awareness, and Updater."""
     from heartbeat import Heartbeat
 
     brain, _ = make_brain([], tmp_memory, empty_skills)
@@ -360,4 +360,159 @@ async def test_heartbeat_wrapper_starts_both_components(
         await hb.start()
         assert hb._scheduler._scheduler.running
         assert hb._awareness._scheduler.running
+        assert hb._updater._scheduler.running
         await hb.stop()
+
+
+# ── Updater ───────────────────────────────────────────────────────────────────
+
+
+def test_check_for_update_no_upstream(monkeypatch):
+    """Returns (False, ...) when no upstream branch is configured."""
+    from heartbeat.updater import check_for_update
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0]
+        if "fetch" in cmd:
+            return MagicMock(returncode=0, stdout="", stderr="")
+        if "rev-parse" in cmd and "HEAD" == cmd[-1]:
+            return MagicMock(returncode=0, stdout="abc123\n", stderr="")
+        if "rev-parse" in cmd and "@{u}" in cmd[-1]:
+            return MagicMock(returncode=128, stdout="", stderr="fatal: no upstream")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    available, msg = check_for_update()
+    assert not available
+    assert "upstream" in msg.lower() or "configured" in msg.lower()
+
+
+def test_check_for_update_already_up_to_date(monkeypatch):
+    """Returns (False, 'Already up to date') when local == remote HEAD."""
+    from heartbeat.updater import check_for_update
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0]
+        if "fetch" in cmd:
+            return MagicMock(returncode=0, stdout="", stderr="")
+        # Both rev-parse calls return the same hash
+        return MagicMock(returncode=0, stdout="abc123\n", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    available, msg = check_for_update()
+    assert not available
+    assert "up to date" in msg.lower()
+
+
+def test_check_for_update_new_commits(monkeypatch):
+    """Returns (True, ...) when the remote is ahead of local HEAD."""
+    from heartbeat.updater import check_for_update
+
+    call_count = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0]
+        if "fetch" in cmd:
+            return MagicMock(returncode=0, stdout="", stderr="")
+        if "rev-parse" in cmd and cmd[-1] == "HEAD":
+            return MagicMock(returncode=0, stdout="aaaa\n", stderr="")
+        if "rev-parse" in cmd and "@{u}" in cmd[-1]:
+            return MagicMock(returncode=0, stdout="bbbb\n", stderr="")
+        if "log" in cmd:
+            return MagicMock(
+                returncode=0,
+                stdout="bbbb feat: add new feature\ncccc fix: some bug\n",
+                stderr="",
+            )
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    available, msg = check_for_update()
+    assert available
+    assert "2 new commit" in msg
+
+
+@pytest.mark.asyncio
+async def test_updater_notifies_on_new_commits(monkeypatch):
+    """Updater._check() calls notify_callback when an update is available."""
+    from heartbeat.updater import Updater
+
+    notified = []
+
+    async def mock_notify(text, files):
+        notified.append(text)
+
+    updater = Updater(notify_callback=mock_notify)
+
+    # Patch check_for_update to report an update
+    monkeypatch.setattr(
+        "heartbeat.updater.check_for_update",
+        lambda: (True, "1 new commit:\n  • feat: shiny thing"),
+    )
+    # Patch _run_git to return a stable remote HEAD
+    monkeypatch.setattr(
+        "heartbeat.updater._run_git",
+        lambda *a, **kw: (0, "bbbb"),
+    )
+
+    await updater._check()
+
+    assert len(notified) == 1
+    assert "update available" in notified[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_updater_no_duplicate_notification(monkeypatch):
+    """Updater._check() does NOT re-notify for the same remote HEAD."""
+    from heartbeat.updater import Updater
+
+    notified = []
+
+    async def mock_notify(text, files):
+        notified.append(text)
+
+    updater = Updater(notify_callback=mock_notify)
+    updater._last_reported_remote = "bbbb"  # already reported
+
+    monkeypatch.setattr(
+        "heartbeat.updater.check_for_update",
+        lambda: (True, "1 new commit:\n  • feat: same one"),
+    )
+    monkeypatch.setattr(
+        "heartbeat.updater._run_git",
+        lambda *a, **kw: (0, "bbbb"),
+    )
+
+    await updater._check()
+
+    assert len(notified) == 0  # no duplicate
+
+
+@pytest.mark.asyncio
+async def test_update_self_tool_no_update(tmp_memory, empty_skills):
+    """update_self returns a 'no update' message when already up to date."""
+    from providers.base import LLMResponse, ToolCall
+
+    mock_heartbeat = MagicMock()
+    mock_heartbeat.check_for_update = AsyncMock(
+        return_value=(False, "Already up to date")
+    )
+
+    brain, _ = make_brain(
+        [
+            LLMResponse(
+                content=None,
+                tool_calls=[ToolCall(id="tc1", name="update_self", arguments={})],
+                stop_reason="tool_use",
+            ),
+            LLMResponse(content="No update needed.", tool_calls=[]),
+        ],
+        tmp_memory,
+        empty_skills,
+    )
+    brain.heartbeat = mock_heartbeat
+
+    _, history = await brain.think("Update yourself", conversation_history=[])
+
+    tool_result = next(m for m in history if m.role == "tool")
+    assert "no update available" in tool_result.content.lower()


### PR DESCRIPTION
Implements self-update from GitHub as requested in #9.

Adds a periodic GitHub update checker that notifies the user when new commits are available, and a new `update_self` brain tool that pulls new code, reinstalls dependencies, and restarts the service after user confirmation.

Generated with [Claude Code](https://claude.ai/code)