### PR TITLE
fix: properly await skill coroutines in brain tool dispatch

### DIFF
--- a/brain/tools.py
+++ b/brain/tools.py
@@ -70,18 +70,6 @@ class _TurnState:
     requested_skills: list = field(default_factory=list)  # set by request_skills
 
 
-# ── Async skill bridge ───────────────────────────────────────────────────────
-
-
-def _run_skill_sync(skill: Skill, kwargs: dict):
-    """Run a skill's run() function.
-
-    If the skill is async, returns the coroutine so the caller
-    (_execute_tool) can await it — avoids nesting event loops.
-    """
-    return skill.run(**kwargs)
-
-
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -134,10 +122,7 @@ def _make_skill_tool(skill: Skill) -> BrainTool:
     captured = skill
 
     async def wrapper(**kwargs):
-        # Skills are normally sync; run in thread to avoid blocking loop
-        import asyncio
-
-        return await asyncio.to_thread(_run_skill_sync, captured, kwargs)
+        return await captured.run(**kwargs)
 
     return BrainTool(
         name=f"skill_{skill.name}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydub>=0.25",
     "sentence-transformers>=3.0",
     "ruff>=0.15.8",
-    "dspy-ai>=3.2.0",
+    "dspy>=3.2.0",
     "nest-asyncio>=1.6.0",
 ]
 

--- a/skills/registry.py
+++ b/skills/registry.py
@@ -22,6 +22,7 @@ Design:
 import ast
 import asyncio
 import importlib.util
+import inspect
 import logging
 import shutil
 from pathlib import Path
@@ -78,6 +79,8 @@ class Skill:
                 result = await module_run(**kwargs)
             else:
                 result = await asyncio.to_thread(module_run, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
             return str(result)
         except Exception as e:
             logger.exception(f"Skill '{self.name}' raised an error")

--- a/skills/registry.py
+++ b/skills/registry.py
@@ -70,10 +70,14 @@ class Skill:
         """Execute this skill's run() function. Supports sync and async."""
         if self._module is None:
             return f"Error: {self.name}/tool.py not found or failed to load"
+        module_run = getattr(self._module, "run", None)
+        if module_run is None:
+            return f"Error: skill '{self.name}' has no run() function"
         try:
-            result = self._module.run(**kwargs)
-            if asyncio.iscoroutine(result):
-                return await result
+            if asyncio.iscoroutinefunction(module_run):
+                result = await module_run(**kwargs)
+            else:
+                result = await asyncio.to_thread(module_run, **kwargs)
             return str(result)
         except Exception as e:
             logger.exception(f"Skill '{self.name}' raised an error")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -18,7 +18,6 @@ from brain.engine import (
 )
 from brain.tools import (
     _TurnState,
-    _run_skill_sync,
     _make_skill_tool,
     _make_remember,
     _make_forget,
@@ -255,24 +254,14 @@ def test_turn_state_initialization():
     assert state.current_plan is None
 
 
-def test_run_skill_sync():
-    """Bridge function executes skill run()."""
-    mock_skill = MagicMock()
-    mock_skill.run.return_value = "skill result"
-    result = _run_skill_sync(mock_skill, {"a": 1})
-    assert result == "skill result"
-    mock_skill.run.assert_called_with(a=1)
-
-
 @pytest.mark.asyncio
 async def test_make_skill_tool_is_async_bridge():
-    """_make_skill_tool wraps a sync skill in an async function."""
+    """_make_skill_tool wraps a skill in an async function that awaits Skill.run."""
     mock_skill = MagicMock()
     mock_skill.name = "test"
     mock_skill.description = "desc"
     mock_skill._module = MagicMock()
-    # Skills are run in thread, so mock the run to be a regular function
-    mock_skill.run = MagicMock(return_value="res")
+    mock_skill.run = AsyncMock(return_value="res")
 
     tool = _make_skill_tool(mock_skill)
     assert tool.name == "skill_test"
@@ -280,6 +269,7 @@ async def test_make_skill_tool_is_async_bridge():
 
     result = await tool(x=10)
     assert result == "res"
+    mock_skill.run.assert_awaited_with(x=10)
 
 
 @pytest.mark.asyncio

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -8,6 +8,7 @@ Tests for the addon skill management system:
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+import pytest
 
 
 # ── SkillRegistry fixtures ─────────────────────────────────────────────────────
@@ -83,6 +84,29 @@ def test_install_skill_immediately_available(tmp_path):
 
     assert skill is not None
     assert skill.source == "addon"
+
+
+@pytest.mark.asyncio
+async def test_sync_run_wrapper_returning_coroutine_is_awaited(tmp_path):
+    from skills.registry import Skill
+
+    skill_dir = tmp_path / "wrapped"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# wrapped")
+    (skill_dir / "tool.py").write_text(
+        """\
+async def _actual(msg: str) -> str:
+    return f"wrapped: {msg}"
+
+def run(msg: str = "ok", **_):
+    return _actual(msg)
+"""
+    )
+
+    skill = Skill("wrapped", "wrapped skill", skill_dir)
+    result = await skill.run(msg="hello")
+
+    assert result == "wrapped: hello"
 
 
 def test_install_invalid_name(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -214,7 +214,7 @@ dependencies = [
     { name = "apscheduler" },
     { name = "ddgs" },
     { name = "discord-py" },
-    { name = "dspy-ai" },
+    { name = "dspy" },
     { name = "fastapi" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
@@ -240,7 +240,7 @@ requires-dist = [
     { name = "apscheduler", specifier = ">=3.10,<4" },
     { name = "ddgs", specifier = ">=9.11.2" },
     { name = "discord-py", specifier = ">=2.3" },
-    { name = "dspy-ai", specifier = ">=3.2.0" },
+    { name = "dspy", specifier = ">=3.2.0" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "google-api-python-client", specifier = ">=2.120" },
     { name = "google-auth-httplib2", specifier = ">=0.2" },
@@ -727,18 +727,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/ab4b3ba261962cf1cd0456113253290329de5c80296ce968f060195c4a03/dspy-3.2.0.tar.gz", hash = "sha256:70593061e8d3df7924e6b7bfe5e61d064e5990f1505b82380b49252b00a88fd7", size = 278448, upload-time = "2026-04-21T17:15:49.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/aa/5b064672fe12bdeb36bda5a70213a773122166ded763d2ccf4dad6eb145b/dspy-3.2.0-py3-none-any.whl", hash = "sha256:cbf82a3ddcd69df071db6cdf7455e7304d66cd47fcb09c856454739414e16d89", size = 331038, upload-time = "2026-04-21T17:15:48.703Z" },
-]
-
-[[package]]
-name = "dspy-ai"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dspy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/c3/fbe81d4eac35e81fbacbbad255a49efb46e43daf1f89103bf86e445e13b5/dspy_ai-3.2.0.tar.gz", hash = "sha256:ec43e535124f7f07f232a2310d4194aa5cc91665559cd2d9829398e606296be4", size = 1124, upload-time = "2026-04-21T17:15:58.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/dc/532f6996603fc30d7f55366751cc843e6e95f312776241e928cd3b21391f/dspy_ai-3.2.0-py3-none-any.whl", hash = "sha256:cdd078d67619a1b86fc3ff5343d91fcefd38a4eb1f6b0aa2179f4cf74e1adde9", size = 1095, upload-time = "2026-04-21T17:15:56.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The skill tool wrapper called Skill.run via asyncio.to_thread + a sync
bridge, but Skill.run is itself an async method. The thread received the
unawaited coroutine and returned it through the wrapper, leaving the
real skill body to never execute and turning every skill call into the
string "<coroutine object Skill.run at 0x...>".

Await Skill.run directly from the wrapper and move the
sync-skill-to-thread offload into Skill.run itself, where it can
distinguish coroutine functions from sync ones.