### PR TITLE
Increase default LLM max tokens and ensure env-backed max_tokens is used

### DIFF
--- a/brain/compactor.py
+++ b/brain/compactor.py
@@ -151,7 +151,7 @@ async def maybe_compact_history(
         response = await provider.complete(
             messages=[Message(role="user", content=old_text)],
             system=system_prompt,
-            max_tokens=int(os.getenv("LLM_MAX_TOKENS", "4096")),
+            max_tokens=int(os.getenv("LLM_MAX_TOKENS", "8192")),
         )
         summary = (response.content or "").strip()
         if not summary:

--- a/brain/dspy_adapter.py
+++ b/brain/dspy_adapter.py
@@ -16,7 +16,7 @@ class AtlasLM(dspy.LM):
     """
     def __init__(self, atlas_provider: BaseLLMProvider, **kwargs):
         self.atlas_provider = atlas_provider
-        kwargs.setdefault("max_tokens", int(os.getenv("LLM_MAX_TOKENS", "4096")))
+        kwargs.setdefault("max_tokens", int(os.getenv("LLM_MAX_TOKENS", "8192")))
         super().__init__(model=atlas_provider.model_name, **kwargs)
 
     @property

--- a/brain/engine.py
+++ b/brain/engine.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 # ReAct parameters
 MAX_ITERATIONS = 8
-MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "4096"))
+MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "8192"))
 TRACE_DIR = Path("logs/traces")
 TRACE_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -8,9 +8,9 @@ AGENT_NAME=Atlas
 # ── LLM Provider ─────────────────────────────────────────────────────────────
 # Supported: anthropic, openai, ollama, openrouter
 LLM_PROVIDER=ollama
-# Maximum tokens the model may generate per response (default: 4096).
-# Increase for long-form answers; Claude supports up to 8192 (Sonnet) or 16384 (Opus).
-# LLM_MAX_TOKENS=8192
+# Maximum tokens the model may generate per response (default: 8192).
+# Increase for long-form answers when supported by your selected model.
+LLM_MAX_TOKENS=8192
 
 # ── Anthropic (Claude) ────────────────────────────────────────────────────────
 # ANTHROPIC_API_KEY=sk-ant-your-key-here

--- a/heartbeat/maintenance.py
+++ b/heartbeat/maintenance.py
@@ -39,7 +39,7 @@ AWARENESS_CONSOLIDATION_THRESHOLD = int(
 AWARENESS_LOG_FILE = MEMORY_DIR / "awareness_log.json"
 EMBEDDINGS_FILE = MEMORY_DIR / "embeddings.json"
 
-MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "4096"))
+MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "8192"))
 
 
 # ── Orchestrator ─────────────────────────────────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -430,7 +430,7 @@ def _run_setup() -> None:
         default=existing.get("LLM_PROVIDER", "ollama"),
         choices=["anthropic", "openai", "ollama", "openrouter"],
     )
-    config["LLM_MAX_TOKENS"] = Prompt.ask(
+    config["LLM_MAX_TOKENS"] = _prompt_positive_integer(
         "Max output tokens per response",
         default=existing.get("LLM_MAX_TOKENS", "8192"),
     )
@@ -507,6 +507,15 @@ def _run_setup() -> None:
 
     _write_env(config)
     console.print(f"\n[green]✓[/green] Saved to [bold]{ENV_FILE}[/bold]")
+
+
+def _prompt_positive_integer(label: str, *, default: str) -> str:
+    """Prompt until the user provides a positive integer string."""
+    while True:
+        value = Prompt.ask(label, default=default).strip()
+        if value.isdigit() and int(value) > 0:
+            return value
+        console.print("[bold red]Please enter a positive whole number.[/bold red]")
 
 
 def _write_env(config: dict[str, str]) -> None:

--- a/main.py
+++ b/main.py
@@ -430,6 +430,10 @@ def _run_setup() -> None:
         default=existing.get("LLM_PROVIDER", "ollama"),
         choices=["anthropic", "openai", "ollama", "openrouter"],
     )
+    config["LLM_MAX_TOKENS"] = Prompt.ask(
+        "Max output tokens per response",
+        default=existing.get("LLM_MAX_TOKENS", "8192"),
+    )
 
     provider = config["LLM_PROVIDER"]
 
@@ -516,7 +520,7 @@ def _write_env(config: dict[str, str]) -> None:
         ),
         (
             "# ── LLM Provider ─────────────────────────────────────────────────────────────",
-            ["LLM_PROVIDER"],
+            ["LLM_PROVIDER", "LLM_MAX_TOKENS"],
         ),
         (
             "# ── Anthropic (Claude) ────────────────────────────────────────────────────────",

--- a/memory/summariser.py
+++ b/memory/summariser.py
@@ -64,7 +64,7 @@ async def maybe_summarise(store: MemoryStore, provider: BaseLLMProvider) -> bool
                 "into a dense, accurate summary. Never lose important facts. "
                 "Output only the summary paragraph."
             ),
-            max_tokens=int(os.getenv("LLM_MAX_TOKENS", "4096")),
+            max_tokens=int(os.getenv("LLM_MAX_TOKENS", "8192")),
         )
         summary = (response.content or "").strip()
         if not summary:
@@ -152,7 +152,7 @@ async def maybe_summarise_history(
         response = await provider.complete(
             messages=[Message(role="user", content=prompt)],
             system="You are a conversation summarizer. Distill the history into a concise background block.",
-            max_tokens=int(os.getenv("LLM_MAX_TOKENS", "4096")),
+            max_tokens=int(os.getenv("LLM_MAX_TOKENS", "8192")),
         )
         summary = (response.content or "").strip()
         if not summary:

--- a/providers/anthropic_provider.py
+++ b/providers/anthropic_provider.py
@@ -7,6 +7,7 @@ LLM provider for Anthropic's Claude models.
 import os
 import anthropic
 from .base import BaseLLMProvider, Message, ToolDefinition, ToolCall, LLMResponse
+from .settings import DEFAULT_MAX_TOKENS
 
 
 class AnthropicProvider(BaseLLMProvider):
@@ -23,7 +24,7 @@ class AnthropicProvider(BaseLLMProvider):
         messages: list[Message],
         tools: list[ToolDefinition] | None = None,
         system: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
         json_mode: bool = False,
     ) -> LLMResponse:
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -8,6 +8,7 @@ Every provider must implement `complete()` — that's the only contract.
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Awaitable
 from dataclasses import dataclass, field
+from .settings import DEFAULT_MAX_TOKENS
 
 
 @dataclass
@@ -63,7 +64,7 @@ class BaseLLMProvider(ABC):
         messages: list[Message],
         tools: list[ToolDefinition] | None = None,
         system: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
         json_mode: bool = False,
     ) -> LLMResponse:
         """
@@ -87,7 +88,7 @@ class BaseLLMProvider(ABC):
         messages: list[Message],
         tools: list[ToolDefinition] | None = None,
         system: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
         on_token: Callable[[str], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         """

--- a/providers/logging_provider.py
+++ b/providers/logging_provider.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from collections.abc import Callable, Awaitable
 from .base import BaseLLMProvider, Message, ToolDefinition, LLMResponse
+from .settings import DEFAULT_MAX_TOKENS
 
 
 def _message_to_dict(msg: Message) -> dict:
@@ -50,7 +51,7 @@ class LoggingProvider(BaseLLMProvider):
         messages: list[Message],
         tools: list[ToolDefinition] | None = None,
         system: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
         json_mode: bool = False,
     ) -> LLMResponse:
         ts = datetime.now(timezone.utc).isoformat()
@@ -91,7 +92,7 @@ class LoggingProvider(BaseLLMProvider):
         messages: list[Message],
         tools: list[ToolDefinition] | None = None,
         system: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
         on_token: Callable[[str], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         """Stream via inner provider; log the completed response afterward."""

--- a/providers/openai_provider.py
+++ b/providers/openai_provider.py
@@ -9,6 +9,7 @@ import os
 from collections.abc import Callable, Awaitable
 import openai
 from .base import BaseLLMProvider, Message, ToolDefinition, ToolCall, LLMResponse
+from .settings import DEFAULT_MAX_TOKENS
 
 
 class OpenAIProvider(BaseLLMProvider):
@@ -31,7 +32,7 @@ class OpenAIProvider(BaseLLMProvider):
         messages: list[Message],
         tools: list[ToolDefinition] | None = None,
         system: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
         json_mode: bool = False,
     ) -> LLMResponse:
         """Send messages to OpenAI and return a unified LLMResponse."""
@@ -100,7 +101,7 @@ class OpenAIProvider(BaseLLMProvider):
         messages: list[Message],
         tools: list[ToolDefinition] | None = None,
         system: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
         on_token: Callable[[str], Awaitable[None]] | None = None,
     ) -> LLMResponse:
         """Stream tokens via on_token callback; return full LLMResponse when done."""

--- a/providers/settings.py
+++ b/providers/settings.py
@@ -1,0 +1,8 @@
+"""
+Shared provider-level settings.
+"""
+
+import os
+
+
+DEFAULT_MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "8192"))


### PR DESCRIPTION
### Motivation
- Some LLM calls fell back to a hard-coded `4096` when callers omitted `max_tokens`, which caused requests to hit model limits; the default should be raised and consistently sourced from the environment.
- Make it easy to persist an increased default via the setup wizard so generated `config/.env` files contain the chosen value.

### Description
- Added `providers/settings.py` with `DEFAULT_MAX_TOKENS = int(os.getenv("LLM_MAX_TOKENS", "8192"))` and wired providers to use it as the default for `max_tokens` in signatures (`BaseLLMProvider`, `OpenAIProvider`, `AnthropicProvider`, `LoggingProvider`).
- Replaced scattered hard-coded `4096` fallbacks with `8192` or env-backed lookups at runtime call sites in `brain/engine.py`, `heartbeat/maintenance.py`, `brain/compactor.py`, `brain/dspy_adapter.py`, and `memory/summariser.py` so callers that omit `max_tokens` inherit the env default.
- Updated the interactive setup flow in `main.py` to prompt for `LLM_MAX_TOKENS` and include it in `_write_env`, and made `config/.env.example` explicitly set `LLM_MAX_TOKENS=8192`.

### Testing
- Ran targeted unit tests with `uv run python -m pytest tests/test_engine.py tests/test_maintenance.py tests/test_streaming.py -q` and the suite passed (`35 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0861ef188832084d166f04737045e)